### PR TITLE
chore: Pin Docker image digests and add Dependabot docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 99
+    assignees:
+      - ffflorian
+    versioning-strategy: increase
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM hugomods/hugo:go-git-0.160.0 AS builder
+FROM hugomods/hugo:go-git-0.160.0@sha256:dc6c89511ecd2f5d7ff158aaa1de7c89c09e9fcf7d93829748a515f16c78ea48 AS builder
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ COPY . ./
 RUN hugo --minify
 
 # Serve
-FROM nginx:alpine
+FROM nginx:alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/public /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- pin Docker base images to current digests
- pin Dockerfile-installed packages where they are managed directly in the Dockerfile
- add or update Dependabot Docker configuration with monthly updates for @ffflorian
