### PR TITLE
chore: remove invalid Dependabot docker versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     open-pull-requests-limit: 99
     assignees:
       - ffflorian
-    versioning-strategy: increase
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary
- remove the unsupported `versioning-strategy` property from Dependabot Docker update entries
- keep the existing monthly schedule, assignee, and pull request limit for Docker updates
