### PR TITLE
chore: ignore Node 25 Docker updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     open-pull-requests-limit: 99
     assignees:
       - ffflorian
+    ignore:
+      - dependency-name: node
+        versions:
+          - '>= 25, < 26'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary
- add a Dependabot Docker ignore rule for the `node` image
- ignore Node 25 tags while still allowing Node 26 and newer majors
